### PR TITLE
ripemd160: fix byte order for big endian systems

### DIFF
--- a/hash/ripemd160.c
+++ b/hash/ripemd160.c
@@ -228,7 +228,7 @@ void ripemd160Final(Ripemd160Context *context, uint8_t *digest)
    ripemd160ProcessBlock(context);
 
    //Convert from host byte order to little-endian byte order
-   for(i = 0; i < 4; i++)
+   for(i = 0; i < 5; i++)
    {
       context->h[i] = htole32(context->h[i]);
    }


### PR DESCRIPTION
Fix hash last word byte order for big endian systems